### PR TITLE
Add required quotes around CFLAGS

### DIFF
--- a/makefile.include
+++ b/makefile.include
@@ -102,7 +102,7 @@ ifeq ($(PLAT),win)
 	cp libz.a ../lib/libz.a && \
 	cp zlib.h zconf.h ../include/
 else
-	cd $@ && CC=$(CC) CFLAGS=$(CFLAGS) sh configure && \
+	cd $@ && CC=$(CC) CFLAGS="$(CFLAGS)" sh configure && \
 	$(MAKE) install prefix=..
 endif
 


### PR DESCRIPTION
Correctly quote CFLAGS to avoid build failure if more than one flag is passed (`make CFLAGS="-m32 -O3"` for instance),
