### PR TITLE
Fix multiple issues when building on Windows/Linux/Darwin 2019

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ versions.vc
 /8.x/mk/builds/
 /8.x/mk/win/Debug/
 /8.x/mk/win/Release/
+.DS_Store

--- a/8.x/tclvfs/generic/vfs.c
+++ b/8.x/tclvfs/generic/vfs.c
@@ -23,10 +23,10 @@
 #ifdef HAVE_SYS_STAT_H
 #  include <sys/stat.h>
 #endif
+#include "tclPort.h"
 #include <tcl.h>
 /* Required to access the 'stat' structure fields, and TclInExit() */
 #include "tclInt.h"
-#include "tclPort.h"
 
 /*
  * Windows needs to know which symbols to export.  Unix does not.

--- a/config.sh
+++ b/config.sh
@@ -46,7 +46,7 @@ case $cli-$dyn-$gui in 0-0-0) cli=1 dyn=1 gui=1 ;; esac
         *) echo "GUI_OPTS   = -L/usr/X11R6/lib -lX11 -weak-lXss -lXext" ;;
       esac
 
-      echo "LDFLAGS    = -framework CoreFoundation"
+      echo "LDFLAGS    = -F/System/Library/Frameworks -framework CoreFoundation -framework AppKit"
       echo "LDSTRIP    = -x"
 
       case $b64-$univ-$ppc-$x86 in
@@ -58,8 +58,8 @@ case $cli-$dyn-$gui in 0-0-0) cli=1 dyn=1 gui=1 ;; esac
         1-0-0-1) echo "CFLAGS    += -arch x86_64" ;;
         1-?-?-?) echo "CFLAGS    += -arch ppc64 -arch x86_64" ;;
       esac
-      echo "CFLAGS    += -isysroot /Developer/SDKs/MacOSX10.4u.sdk" \
-                          "-mmacosx-version-min=10.4"
+      echo "CFLAGS    += -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk" \
+                          "-mmacosx-version-min=10.6"
 
       case $aqua in 1)
         echo "TK_OPTS    = --enable-aqua"

--- a/config.sh
+++ b/config.sh
@@ -70,7 +70,7 @@ case $cli-$dyn-$gui in 0-0-0) cli=1 dyn=1 gui=1 ;; esac
     Linux)
       echo "CC         = ${CC:=gcc}"
       echo "CXX        = ${CXX:=gcc}"
-      echo "LDFLAGS    = -ldl -lm"
+      echo "LDFLAGS    = -ldl -lm -lfontconfig"
       echo "LDXXFLAGS  = -Wl,-Bstatic -lstdc++ -Wl,-Bdynamic"
       echo "GUI_OPTS   = -L/usr/X11R6/lib -lX11 -lXss"
       if [ $root != "8.4" ]; then

--- a/config.sh
+++ b/config.sh
@@ -66,6 +66,8 @@ case $cli-$dyn-$gui in 0-0-0) cli=1 dyn=1 gui=1 ;; esac
         echo "TK_OPTS    = --enable-aqua"
         echo "TKDYN_OPTS = --enable-aqua" ;;
       esac
+      [ -x "$upx" ] || upx=':'
+      echo "UPX        = $upx"
       ;;
 
     Linux)

--- a/config.sh
+++ b/config.sh
@@ -41,6 +41,7 @@ case $cli-$dyn-$gui in 0-0-0) cli=1 dyn=1 gui=1 ;; esac
   case $mach in
 
     Darwin)
+      sed -i '' 's/?=.so/?=.dylib/g' makefile.include
       case $aqua in
         1) echo "GUI_OPTS   = -framework Carbon -framework IOKit" ;;
         *) echo "GUI_OPTS   = -L/usr/X11R6/lib -lX11 -weak-lXss -lXext" ;;

--- a/makefile.include
+++ b/makefile.include
@@ -102,7 +102,7 @@ ifeq ($(PLAT),win)
 	cp libz.a ../lib/libz.a && \
 	cp zlib.h zconf.h ../include/
 else
-	cd $@ && CC=$(CC) CFLAGS=$(CFLAGS) sh configure && \
+	cd $@ && CC=$(CC) CFLAGS="$(CFLAGS)" sh configure && \
 	$(MAKE) install prefix=..
 endif
 


### PR DESCRIPTION
Trying to build Tclkit recently with Tcl/Tk 8.6.9:

To be specific, it's [tcl8.6.9-src.tar.gz](https://prdownloads.sourceforge.net/tcl/tcl8.6.9-src.tar.gz) and [tk8.6.9.1-src.tar.gz](https://prdownloads.sourceforge.net/tcl/tk8.6.9.1-src.tar.gz).

There's a lot of things should change to make it work.

And now it works, here's the code.


------

I agree with @l3iggs about tags or release [here](https://github.com/patthoyts/kitgen/issues/8), maybe we should get one.

And [this](https://github.com/patthoyts/kitgen/pull/9) PR is included already.